### PR TITLE
covergae dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,25 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.10</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.3.0</version>


### PR DESCRIPTION
Adding jacoco dependency to create coverage reports.

Reports can be foud: /target/site/jacoco/com.java.thalys.routing/index.html